### PR TITLE
Added `Provider.getConfirmations(txHash: string)` method

### DIFF
--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -54,6 +54,12 @@ class Blockfrost implements Provider {
     return getAddressUtxos(this.blockfrost, address, this.limit, 1, !!paginate);
   }
 
+  async getConfirmations(txHash: string) {
+    const tx = await this.blockfrost.txs(txHash)
+    const latestBlock = await this.blockfrost.blocksLatest()
+    return latestBlock.height ? latestBlock.height - tx.block_height : 0
+  }
+
   async getAssetAddresses(assetId: string) {
     return paginate(
       (page) => this.blockfrost.assetsAddresses(assetId, { page }),

--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -55,9 +55,13 @@ class Blockfrost implements Provider {
   }
 
   async getConfirmations(txHash: string) {
-    const tx = await this.blockfrost.txs(txHash)
-    const latestBlock = await this.blockfrost.blocksLatest()
-    return latestBlock.height ? latestBlock.height - tx.block_height : 0
+    const tx = await fetchWithFallback(() => this.blockfrost.txs(txHash), null);
+    invariant(tx, `Transaction with hash ${txHash} not found`);
+
+    const latestBlock = await fetchWithFallback(() => this.blockfrost.blocksLatest(), null);
+    invariant(latestBlock, "Latest block information not found");
+
+    return latestBlock.height ? latestBlock.height - tx.block_height + 1 : 0;
   }
 
   async getAssetAddresses(assetId: string) {

--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -58,7 +58,10 @@ class Blockfrost implements Provider {
     const tx = await fetchWithFallback(() => this.blockfrost.txs(txHash), null);
     invariant(tx, `Transaction with hash ${txHash} not found`);
 
-    const latestBlock = await fetchWithFallback(() => this.blockfrost.blocksLatest(), null);
+    const latestBlock = await fetchWithFallback(
+      () => this.blockfrost.blocksLatest(),
+      null
+    );
     invariant(latestBlock, "Latest block information not found");
 
     return latestBlock.height ? latestBlock.height - tx.block_height + 1 : 0;

--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -55,13 +55,11 @@ class Blockfrost implements Provider {
   }
 
   async getConfirmations(txHash: string) {
-    const tx = await fetchWithFallback(() => this.blockfrost.txs(txHash), null);
+    const [tx, latestBlock] = await Promise.all([
+      fetchWithFallback(() => this.blockfrost.txs(txHash), null),
+      fetchWithFallback(() => this.blockfrost.blocksLatest(), null),
+    ]);
     invariant(tx, `Transaction with hash ${txHash} not found`);
-
-    const latestBlock = await fetchWithFallback(
-      () => this.blockfrost.blocksLatest(),
-      null
-    );
     invariant(latestBlock, "Latest block information not found");
 
     return latestBlock.height ? latestBlock.height - tx.block_height + 1 : 0;

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -10,14 +10,15 @@ type AssetAddress = {
 };
 
 type Provider = {
-  network: "mainnet" | "preprod" | "preview";
   findAllTokens: (policyId: string) => Promise<Address[]>;
   findToken: (tokenId: string) => Promise<Address>;
   findTokensOf: (policyId: string) => Promise<Asset[]>;
-  getStakedAddresses: (stakeKey: string) => Promise<Address[]>;
   getAssetAddresses: (assetId: string) => Promise<AssetAddress[]>;
+  getConfirmations: (txHash: string) => Promise<number>;
+  getStakedAddresses: (stakeKey: string) => Promise<Address[]>;
   getTokenHistory: (tokenId: string, limit: number) => Promise<OutRef[]>;
   getUtxos: (address: string, paginate?: boolean) => Promise<UTxO[]>;
+  network: "mainnet" | "preprod" | "preview";
 };
 
 export default Provider;

--- a/src/tests/blockfrost.test.ts
+++ b/src/tests/blockfrost.test.ts
@@ -109,3 +109,11 @@ test("blockfrost: getTokenHistory", async (t) => {
   t.ok(history.length > 50);
   t.end();
 });
+
+test("blockfrost: getConfirmations", async (t) => {
+  const confirmations = await blockfrost.getConfirmations(
+    "9dbe50247cadc5211f2108f4fe7f614abcf76e550e7f176afd30743ac0776806",
+  );
+  t.ok(confirmations > 50);
+  t.end();
+});

--- a/src/tests/blockfrost.test.ts
+++ b/src/tests/blockfrost.test.ts
@@ -112,7 +112,7 @@ test("blockfrost: getTokenHistory", async (t) => {
 
 test("blockfrost: getConfirmations", async (t) => {
   const confirmations = await blockfrost.getConfirmations(
-    "9dbe50247cadc5211f2108f4fe7f614abcf76e550e7f176afd30743ac0776806",
+    "9dbe50247cadc5211f2108f4fe7f614abcf76e550e7f176afd30743ac0776806"
   );
   t.ok(confirmations > 50);
   t.end();


### PR DESCRIPTION
In this PR I add the functionality through the `txHash` of a transaction obtain the number of blockchain confirmations.
