### PR TITLE
Added `parallel` argument to `Provider.getAssetAddresses` method

### DIFF
--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -71,11 +71,11 @@ class Blockfrost implements Provider {
     return height - tx.block_height + 1;
   }
 
-  async getAssetAddresses(assetId: string) {
+  async getAssetAddresses(assetId: string, parallel?: number) {
     return paginate(
       (page) => this.blockfrost.assetsAddresses(assetId, { page }),
       this.limit,
-      this.parallel
+      parallel ?? this.parallel
     );
   }
 

--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -75,7 +75,7 @@ class Blockfrost implements Provider {
     return paginate(
       (page) => this.blockfrost.assetsAddresses(assetId, { page }),
       this.limit,
-      parallel ?? this.parallel
+      parallel && parallel > 0 ? parallel : this.parallel
     );
   }
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -13,7 +13,10 @@ type Provider = {
   findAllTokens: (policyId: string) => Promise<Address[]>;
   findToken: (tokenId: string) => Promise<Address>;
   findTokensOf: (policyId: string) => Promise<Asset[]>;
-  getAssetAddresses: (assetId: string) => Promise<AssetAddress[]>;
+  getAssetAddresses: (
+    assetId: string,
+    parallel?: number
+  ) => Promise<AssetAddress[]>;
   getConfirmations: (txHash: string) => Promise<number>;
   getHeight: () => Promise<number>;
   getStakedAddresses: (stakeKey: string) => Promise<Address[]>;


### PR DESCRIPTION
In this PR I propose adding a `parallel` argument to `Provider.getAssetAddresses` method to allow limiting simultaneous pagination