### PR TITLE
Allow `getUtxos` method to return more than 100 UTxOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.vscode/settings.json

--- a/src/providers/blockfrost/blockfrost.ts
+++ b/src/providers/blockfrost/blockfrost.ts
@@ -47,11 +47,8 @@ class Blockfrost implements Provider {
     return addresses[0].address;
   }
 
-  getUtxos(address: string, paginate?: boolean) {
-    // Addresses typically don't have many UTXOs, so don't
-    // load multiple pages since that'll only slow down the
-    // results
-    return getAddressUtxos(this.blockfrost, address, this.limit, 1, !!paginate);
+  getUtxos(address: string) {
+    return getAddressUtxos(this.blockfrost, address, this.limit);
   }
 
   async getHeight() {

--- a/src/providers/blockfrost/utxos.ts
+++ b/src/providers/blockfrost/utxos.ts
@@ -2,7 +2,6 @@ import { BlockFrostAPI } from "@blockfrost/blockfrost-js";
 import { components } from "@blockfrost/openapi";
 import { UTxO } from "@lucid-evolution/lucid";
 import { LimitFunction } from "p-limit";
-import paginate from "./paginate.js";
 import { fetchWithFallback } from "./utils.js";
 
 type ElementType<T> = T extends (infer U)[] ? U : never;
@@ -13,17 +12,12 @@ type BlockfrostUtxo = ElementType<
 const getAddressUtxos = async (
   blockfrost: BlockFrostAPI,
   address: string,
-  limit: LimitFunction,
-  parallel: number,
-  shouldPaginate: boolean
+  limit: LimitFunction
 ): Promise<UTxO[]> => {
-  const utxos = shouldPaginate
-    ? await paginate(
-        (page) => blockfrost.addressesUtxos(address, { page }),
-        limit,
-        parallel
-      )
-    : await fetchWithFallback(() => blockfrost.addressesUtxos(address), []);
+  const utxos = await fetchWithFallback(
+    () => blockfrost.addressesUtxos(address),
+    []
+  );
 
   return await Promise.all(
     utxos.map((utxo) => toUtxo(utxo, blockfrost, limit))

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -31,7 +31,7 @@ type Provider = {
   getMetadata: (tx: string) => Promise<Metadata[]>;
   getStakedAddresses: (stakeKey: string) => Promise<Address[]>;
   getTokenHistory: (tokenId: string, limit: number) => Promise<OutRef[]>;
-  getUtxos: (address: string, paginate?: boolean) => Promise<UTxO[]>;
+  getUtxos: (address: string) => Promise<UTxO[]>;
   network: "mainnet" | "preprod" | "preview";
 };
 

--- a/src/tests/blockfrost.test.ts
+++ b/src/tests/blockfrost.test.ts
@@ -91,7 +91,7 @@ test(
     const utxos = await blockfrost.getUtxos(
       "addr_test1qzqgms3rckd6ljgej4uq0ahrfa4nlppxs0en9qysxfhyzttt9f7xfrtr7gk8xqaup43yyzm6vmlg74ms3yqycsluu00qxwj04a"
     );
-    t.equal(utxos.length, 121);
+    t.equal(utxos.length, 120);
     t.end();
   },
   { timeout: 9000 }

--- a/src/tests/blockfrost.test.ts
+++ b/src/tests/blockfrost.test.ts
@@ -85,6 +85,18 @@ test(
   { timeout: 9000 }
 );
 
+test(
+  "blockfrost: getUtxos returns more than 100",
+  async (t) => {
+    const utxos = await blockfrost.getUtxos(
+      "addr_test1qzqgms3rckd6ljgej4uq0ahrfa4nlppxs0en9qysxfhyzttt9f7xfrtr7gk8xqaup43yyzm6vmlg74ms3yqycsluu00qxwj04a"
+    );
+    t.equal(utxos.length, 121);
+    t.end();
+  },
+  { timeout: 9000 }
+);
+
 test("blockfrost: getStakedAddresses", async (t) => {
   const addresses = await blockfrost.getStakedAddresses(
     "stake_test1uz7tnvcj8qy92r2mtlrxugwcnec6ck72c9gp5t5h3jd0qkshdk2kv"


### PR DESCRIPTION
In this PR I propose an update to the `Blockfrost.getUtxos` method to allow returning all the UTxOs. Previously there was an issue where only a maximum of 100 UTxOs were returned.